### PR TITLE
Add permissions for artifact attestation in Docker workflow

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -45,6 +45,7 @@ jobs:
       contents: read
       packages: write
       id-token: write # Needed for artifact attestation
+      attestations: write # Needed for artifact attestation
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Include necessary permissions for artifact attestation in the Docker workflow configuration.